### PR TITLE
[PKG-1844] Rebuild datashader 0.14.4 for py311

### DIFF
--- a/recipe/0001_do_not_use_warnings_from_numpy.patch
+++ b/recipe/0001_do_not_use_warnings_from_numpy.patch
@@ -1,0 +1,68 @@
+From 141210c8366599190c51987f7de126ff8f689961 Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Tue, 7 Feb 2023 09:15:37 +0100
+Subject: [PATCH] Do not use warnings from numpy
+
+numpy has removed the warnings symbol from the __init__.py file so
+np.warnings is not valid in newer versions of numpy. This patch justs
+imports the warnings module and use it directly.
+---
+ datashader/core.py                        | 6 +++---
+ datashader/transfer_functions/__init__.py | 6 ++++--
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/datashader/core.py b/datashader/core.py
+index 7c5365898..5f175281b 100644
+--- a/datashader/core.py
++++ b/datashader/core.py
+@@ -2,6 +2,7 @@
+ 
+ from numbers import Number
+ from math import log10
++import warnings
+ 
+ import numpy as np
+ import pandas as pd
+@@ -424,7 +425,6 @@ def line(self, source, x=None, y=None, agg=None, axis=0, geometry=None,
+ 
+         if (line_width > 0 and ((cudf and isinstance(source, cudf.DataFrame)) or
+                                (dask_cudf and isinstance(source, dask_cudf.DataFrame)))):
+-            import warnings
+             warnings.warn(
+                 "Antialiased lines are not supported for CUDA-backed sources, "
+                 "so reverting to line_width=0")
+@@ -1255,8 +1255,8 @@ def bypixel(source, canvas, glyph, agg, *, antialias=False):
+     canvas.validate()
+ 
+     # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
+-    with np.warnings.catch_warnings():
+-        np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
++    with warnings.catch_warnings():
++        warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+         return bypixel.pipeline(source, schema, canvas, glyph, agg, antialias=antialias)
+ 
+ 
+diff --git a/datashader/transfer_functions/__init__.py b/datashader/transfer_functions/__init__.py
+index 1a9fffcd0..a60802d9c 100755
+--- a/datashader/transfer_functions/__init__.py
++++ b/datashader/transfer_functions/__init__.py
+@@ -5,6 +5,8 @@
+ from collections import OrderedDict
+ from io import BytesIO
+ 
++import warnings
++
+ import numpy as np
+ import numba as nb
+ import toolz as tz
+@@ -457,8 +459,8 @@ def _interpolate_alpha(data, total, mask, how, alpha, span, min_alpha, rescale_d
+             a_scaled, discrete_levels = a_scaled
+ 
+         # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
+-        with np.warnings.catch_warnings():
+-            np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
++        with warnings.catch_warnings():
++            warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+             norm_span = [np.nanmin(a_scaled).item(), np.nanmax(a_scaled).item()]
+ 
+         if rescale_discrete_levels and discrete_levels is not None:  # Only valid for how='eq_hist'

--- a/recipe/0002_fix_inspect_has_no_attribute_getargspec.patch
+++ b/recipe/0002_fix_inspect_has_no_attribute_getargspec.patch
@@ -1,0 +1,43 @@
+From 0d5c70d87396a035e0805f966e32f0f469727c7c Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Tue, 30 May 2023 12:05:31 +0300
+Subject: [PATCH] Fix fix inspect has no attribute getargspec
+
+---
+ datashader/glyphs/glyph.py      | 4 ++--
+ datashader/tests/test_macros.py | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/datashader/glyphs/glyph.py b/datashader/glyphs/glyph.py
+index 1a5547c..34f3176 100644
+--- a/datashader/glyphs/glyph.py
++++ b/datashader/glyphs/glyph.py
+@@ -148,10 +148,10 @@ class Glyph(Expr):
+             warnings.simplefilter("ignore")
+             try:
+                 # Numba keeps original function around as append.py_func
+-                append_args = inspect.getargspec(append.py_func).args
++                append_args = inspect.getfullargspec(append.py_func).args
+             except (TypeError, AttributeError):
+                 # Treat append as a normal python function
+-                append_args = inspect.getargspec(append).args
++                append_args = inspect.getfullargspec(append).args
+ 
+         # Get number of arguments accepted by append
+         append_arglen = len(append_args)
+diff --git a/datashader/tests/test_macros.py b/datashader/tests/test_macros.py
+index 2a1433e..488fa39 100644
+--- a/datashader/tests/test_macros.py
++++ b/datashader/tests/test_macros.py
+@@ -34,7 +34,7 @@ def function_with_vararg_call_numba(a, b, *others):
+ def get_args(fn):
+     with warnings.catch_warnings():
+         warnings.simplefilter("ignore")
+-        spec = inspect.getargspec(fn)
++        spec = inspect.getfullargspec(fn)
+ 
+     args = spec.args
+     if spec.varargs:
+-- 
+2.39.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 0241e611f951be3245972708e5a769bb183afbfceeec3cf2eef6d80af7756fbd
 
 build:
+  # trigger 1
   number: 0
   # Currently it's not available on s390x:
   # There are missing datashape, numba, fastparquet, netcdf4.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - dask-core
     - datashape
     - numba >=0.51
-    - numpy >=1.21,<2.0a
+    - numpy
     - pandas
     - param
     - pillow
@@ -47,7 +47,7 @@ test:
   imports:
     - datashader
   requires:
-    - fastparquet
+    - fastparquet  # [py<311]
     - flake8
     - holoviews
     - nbsmoke >0.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/datashader-{{ version }}.tar.gz
   sha256: 0241e611f951be3245972708e5a769bb183afbfceeec3cf2eef6d80af7756fbd
+  patches:
+    # numpy has removed the warnings symbol from the init.py file so np.warnings is not valid in newer versions of numpy. 
+    # See https://github.com/holoviz/datashader/pull/1176
+    # The patch should be removed after the next release of datashader.
+    - 0001_do_not_use_warnings_from_numpy.patch
 
 build:
-  # trigger 1
-  number: 0
+  number: 1
   # Currently it's not available on s390x:
   # There are missing datashape, numba, fastparquet, netcdf4.
   skip: True  # [py<37 or s390x]
@@ -20,6 +24,9 @@ build:
     - datashader = datashader.__main__:main
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - python
     - pip
@@ -47,7 +54,7 @@ test:
   imports:
     - datashader
   requires:
-    - fastparquet  # [py<311]
+    - fastparquet
     - flake8
     - holoviews
     - nbsmoke >0.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
   # Currently it's not available on s390x:
   # There are missing datashape, numba, fastparquet, netcdf4.
   skip: True  # [py<37 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - datashader = datashader.__main__:main
 
@@ -91,3 +91,5 @@ extra:
     - ocefpaf
     - philippjfr
     - jsignell
+  skip-lints:
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - dask-core
     - datashape
     - numba >=0.51
-    - numpy >=1.19,<2.0a
+    - numpy >=1.21,<2.0a
     - pandas
     - param
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
     # See https://github.com/holoviz/datashader/pull/1176
     # The patch should be removed after the next release of datashader.
     - 0001_do_not_use_warnings_from_numpy.patch
+    # Fixed in the main branch of datashader, but not yet released, see https://github.com/holoviz/datashader/commit/31b31826d74da38e4878f87c3e44511d08d302df
+    - 0002_fix_inspect_has_no_attribute_getargspec.patch
 
 build:
   number: 1


### PR DESCRIPTION
Rebuilding because of missing artifacts for py311

Changelog: https://github.com/holoviz/datashader/blob/v0.14.4/CHANGELOG.rst
License: https://github.com/holoviz/datashader/blob/v0.14.4/LICENSE.txt
Requirements:
- https://github.com/holoviz/datashader/blob/v0.14.4/pyproject.toml
- https://github.com/holoviz/datashader/blob/v0.14.4/setup.py

Actions:
1. Add a patch to fix the numpy warnings error, see https://github.com/holoviz/datashader/pull/1218
2. Add a patch to fix `inspect has no attribute getargspec`, see https://github.com/holoviz/datashader/commit/31b31826d74da38e4878f87c3e44511d08d302df
3. Bump the build number
4. Remove `numpy` pinnings following the upstream requirements