### PR TITLE
Release 0.16.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,9 @@ requirements:
     - scipy
     - toolz
     - xarray
+    # packaging is used in the code
+    # https://github.com/holoviz/datashader/blame/v0.16.2/datashader/__init__.py#L3
+    - packaging
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,8 +58,7 @@ test:
     - pytest
     - pytest-benchmark
   commands:
-    - pip check || true    # [not win]
-    - pip check || exit 0  # [win]
+    - pip check
     - datashader --version
     - datashader --help
     - datashader copy-examples --path=. --force

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datashader" %}
-{% set version = "0.16.0" %}
+{% set version = "0.16.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/datashader-{{ version }}.tar.gz
-  sha256: ed4c111957578dcb3fcff972d954f77586dafd71a7345fd5cd069d9fb050d0d1
+  sha256: 7899979b4c1adba6b4fd2e86caa3f5ef94c4e6ab234cbb7306ca6bfe243fc4df
 
 build:
   number: 0


### PR DESCRIPTION
datashader 0.16.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/datashader)
- [Upstream changelog/diff](https://github.com/holoviz/datashader/compare/v0.16.0...v0.16.2#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)

### Explanation of changes:

- As the diff for `setup.py` between 0.16.0 and 0.16.2 shows, there were no updates made to the runtime dependencies of datashader between these versions.
