### PR TITLE
Release 0.16.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datashader" %}
-{% set version = "0.16.2" %}
+{% set version = "0.16.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/datashader-{{ version }}.tar.gz
-  sha256: 7899979b4c1adba6b4fd2e86caa3f5ef94c4e6ab234cbb7306ca6bfe243fc4df
+  sha256: 9d0040c7887f7a5a5edd374c297402fd208a62bf6845e87631b54f03b9ae479d
 
 build:
   number: 0
@@ -33,6 +33,7 @@ requirements:
     - multipledispatch
     - numba
     - numpy
+    - packaging
     - pandas
     - param
     - pillow
@@ -41,9 +42,6 @@ requirements:
     - scipy
     - toolz
     - xarray
-    # packaging is used in the code
-    # https://github.com/holoviz/datashader/blame/v0.16.2/datashader/__init__.py#L3
-    - packaging
 
 test:
   imports:


### PR DESCRIPTION
datashader 0.16.3

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/datashader)
- [Upstream changelog/diff](https://github.com/holoviz/datashader/compare/v0.16.2...v0.16.3#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)
- Relevant dependency PRs:
  - conda-forge: https://github.com/conda-forge/datashader-feedstock/pull/36/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a

### Explanation of changes:

- `packaging` was already added to the conda recipe as it was noticed it was a runtime dependency of datashader. In this release, datashader has clarified this by adding `packaging` to its `setup.py`. So I've removed the comment in the recipe about `packaging`, and moved it up to keep the requirements alphabetically ordered.
