### PR TITLE
datashader 0.18.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,5 +101,3 @@ extra:
     - ocefpaf
     - philippjfr
     - jsignell
-  skip-lints:
-    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,17 @@
 {% set name = "datashader" %}
-{% set version = "0.18.0" %}
+{% set version = "0.18.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/datashader-{{ version }}.tar.gz
-  sha256: 6754f2d5747973e340e57a41cd3b8cb25a5e7ccd16fd945ca46ac2cd823236ec
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 53ef0bc35b9ba1034bdf290a2e28babf0fa2b075a3e5a822c79dcde12183d1ff
 
 build:
   number: 0
-  # Currently it's not available on s390x:
-  # There are missing datashape, numba, fastparquet, netcdf4.
-  skip: True  # [py<310]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - datashader = datashader.__main__:main
@@ -22,42 +20,68 @@ requirements:
   host:
     - python
     - pip
-    - hatchling
     - hatch-vcs
+    - hatchling
   run:
     - python
     - colorcet
     - multipledispatch
     - numba
     - numpy
-    - packaging
     - pandas
     - param
     - pyct
     - requests
     - scipy
     - toolz
+    - packaging
     - xarray
 
 test:
   imports:
     - datashader
+    - datashader.antialias
+    - datashader.bundling
+    - datashader.colors
+    - datashader.compiler
+    - datashader.composite
+    - datashader.core
+    - datashader.data_libraries
+    - datashader.datashape
+    - datashader.datashape.coretypes
+    - datashader.datashape.discovery
+    - datashader.datashape.parser
+    - datashader.datashape.predicates
+    - datashader.datashape.user
+    - datashader.datashape.util
+    - datashader.datashape.util.testing
+    - datashader.datatypes
+    - datashader.glyphs
+    - datashader.glyphs.area
+    - datashader.glyphs.glyph
+    - datashader.glyphs.line
+    - datashader.glyphs.points
+    - datashader.glyphs.quadmesh
+    - datashader.glyphs.trimesh
+    - datashader.layout
+    - datashader.macros
+    - datashader.mpl_ext
+    - datashader.resampling
+    - datashader.tiles
+    - datashader.transfer_functions
+    - datashader.utils
   requires:
-    - fastparquet
-    - flake8
-    - holoviews
-    - nbsmoke >0.5.0
-    - netcdf4
     - pip
     - pytest
-    - pytest-benchmark
+    - matplotlib
+    - netcdf4
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest --pyargs datashader.tests
     - datashader --version
     - datashader --help
     - datashader copy-examples --path=. --force
-    # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
-    - pytest --nbsmoke-run -k ".ipynb" getting_started/2_Pipeline.ipynb
 
 about:
   home: https://datashader.org


### PR DESCRIPTION
datashader 0.18.2 

**Destination channel:** Defaults

### Links

- [PKG-9373]
- dev_url:        https://github.com/holoviz/datashader/tree/v0.18.2
- conda_forge:    https://github.com/conda-forge/datashader-feedstock
- pypi:           https://pypi.org/project/datashader/0.18.2
- pypi inspector: https://inspector.pypi.io/project/datashader/0.18.2

### Explanation of changes:

- new version number


[PKG-9373]: https://anaconda.atlassian.net/browse/PKG-9373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ