### PR TITLE
v0.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datashader" %}
-{% set version = "0.18.2" %}
+{% set version = "0.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 53ef0bc35b9ba1034bdf290a2e28babf0fa2b075a3e5a822c79dcde12183d1ff
+  sha256: beab445a44ac5f1dbc3f562c85d595c886a29dce4cc85eeb9a50723b729d57a2
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-  entry_points:
-    - datashader = datashader.__main__:main
 
 requirements:
   host:
@@ -80,9 +78,6 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest --pyargs datashader.tests
-    - datashader --version
-    - datashader --help
-    - datashader copy-examples --path=. --force
 
 about:
   home: https://datashader.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,7 @@ test:
     - pytest
     - matplotlib
     - netcdf4
+    - hypothesis
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"


### PR DESCRIPTION
datashader v0.19.0

**Destination channel:** defaults

### Links

- [PKG-13275](https://anaconda.atlassian.net/browse/PKG-13275) 
- [Upstream repository](https://github.com/holoviz/datashader/tree/v0.19.0)
- [Upstream changelog/diff](https://github.com/holoviz/datashader/releases/tag/v0.19.0)


### Explanation of changes:

- Bump version and SHA
- Add new test dep
- Remove entrypoint [per upstream](https://github.com/holoviz/datashader/commit/f0736b1ba64ee2805a968c33da6d65f5e63605c2)


[PKG-13275]: https://anaconda.atlassian.net/browse/PKG-13275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ